### PR TITLE
feat: allow globbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ If your platform isn't yet supported, you can create the native binary from
 the latest upstream clang sources, make sure it is stripped and optimized
 (should be about 1.4MB as of mid-2015) and send a pull request to add it.
 
+## Globbing files
+
+    $ clang-format --glob=folder/**/*.js
+
+This will run `clang-format` once per file result, and show the total
+formatted files at the end.
+See [node-glob](https://github.com/isaacs/node-glob) for globbing semantics.
+
 ## Compiling clang-format
 
 For Linux, compile a statically linked MinSizeRel build:

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var os = require('os');
 var path = require('path');
 var resolve = require('resolve').sync;
 var spawn = require('child_process').spawn;
+var glob = require("glob");
+var async = require("async");
 
 var VERSION = require('./package.json').version;
 var LOCATION = __filename;
@@ -48,11 +50,52 @@ function spawnClangFormat(args, done, stdio) {
               "Consider installing it with your native package manager instead.\n";
     throw new Error(message);
   }
-  var clangFormatProcess = spawn(nativeBinary, args, {stdio: stdio});
-  clangFormatProcess.on('close', function(exit) {
-    if (exit) done(exit);
-  });
-  return clangFormatProcess;
+
+  // extract glob, if present
+  var filesGlob = args.filter(function(arg){return arg.indexOf('--glob=') === 0;})
+                    .map(function(arg){return arg.replace('--glob=', '');})
+                    .shift();
+
+  if (filesGlob) {
+    // remove glob from arg list
+    args = args.filter(function(arg){return arg.indexOf('--glob=') === -1;});
+
+    return glob(filesGlob, function(er, files) {
+      // split file array into chunks of 30
+      var i,j, chunks = [], chunkSize = 30;
+      for (i=0,j=files.length; i<j; i+=chunkSize) {
+          chunks.push( files.slice(i,i+chunkSize));
+      }
+
+      // launch a new process for each chunk
+      async.series(
+        chunks.map(function(chunk) {
+          return function(callback) {
+            var clangFormatProcess = spawn(nativeBinary,
+                                          args.concat(chunk),
+                                          {stdio: stdio});
+            clangFormatProcess.on('close', function(exit) {
+              if (exit !== 0) callback(exit);
+              else callback(null, exit);
+            });
+          };
+        }),
+        function(err, results) {
+          if (err) done(err);
+          console.log('\n');
+          console.log('ran clang-format with',
+                      files.length,
+                      files.length === 1 ? 'file path' : 'files path');
+          done(results.shift() || 0);
+        });
+    });
+  } else {
+    var clangFormatProcess = spawn(nativeBinary, args, {stdio: stdio});
+    clangFormatProcess.on('close', function(exit) {
+      if (exit) done(exit);
+    });
+    return clangFormatProcess;
+  }
 }
 
 function main() {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
   },
   "contributors": [
     "Alex Eagle <alexeagle@google.com>",
-    "Martin Probst <martinprobst@google.com>"
+    "Martin Probst <martinprobst@google.com>",
+    "Filipe Silva <filipematossilva@gmail.com>"
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "async": "^1.5.2",
+    "glob": "^7.0.0",
     "resolve": "^1.1.6"
   }
 }

--- a/test.sh
+++ b/test.sh
@@ -16,6 +16,7 @@ echo "[PASS] absolute path" >&2
 
 FULL_SCRIPT_PATH="$PWD/index.js"
 EXPECTED_VERSION_STRING=" at $PWD/testproject/node_modules/" # somewhere in there
+EXPECTED_GLOB_STRING="ran clang-format with 1 file path" # somewhere in there
 
 pushd $PWD/testproject
 npm install &>/dev/null # Should give us a local clang-format, version doesn't really matter.
@@ -33,3 +34,10 @@ if [[ $VERSION != *"$EXPECTED_VERSION_STRING"* ]]; then
   exit 1
 fi
 echo "[PASS] file argument anchors resolution" >&2
+
+GLOB=`/usr/bin/env node $FULL_SCRIPT_PATH -i --glob=testproject/lib/**/*.js`
+if [[ $GLOB != *"$EXPECTED_GLOB_STRING" ]]; then
+  echo "[FAIL] Expected string ending in $EXPECTED_GLOB_STRING, got $GLOB" >&2
+  exit 1
+fi
+echo "[PASS] glob argument resolution" >&2


### PR DESCRIPTION
Close #21
## Globbing files

```
$ clang-format --glob=folder/**/*.js
```

This will run `clang-format` once per file result, and show the total formatted files at the end.
