### PR TITLE
Fail loudly when clang-format is unavailable

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function spawnClangFormat(args, done, stdio) {
   try {
     nativeBinary = getNativeBinary();
   } catch (e) {
-    setImmediate(done.bind(e));
+    setImmediate(() => done(e));
     return;
   }
 
@@ -148,7 +148,14 @@ function main() {
   // Run clang-format.
   try {
     // Pass all arguments to clang-format, including e.g. -version etc.
-    actualSpawnFn(process.argv.slice(2), process.exit, 'inherit');
+    actualSpawnFn(process.argv.slice(2), function(e) {
+      if (e instanceof Error) {
+        console.error(e);
+        process.exit(1);
+      } else {
+        process.exit(e);
+      }
+    }, 'inherit');
   } catch (e) {
     process.stdout.write(e.message);
     process.exit(1);


### PR DESCRIPTION
Without this change, if clang-format is not available for the current
platform (e.g. android_x64), running this tool has no output and exits
with status 0. If clang-format is used to filter files, it would
effectively empty the file.

After this change, clang-format will fail with status 1 and an error
message to stderr.