### PR TITLE
build: specify version of circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ var_4: &save_cache
     paths:
     - "node_modules/"
 
+version: 2
+
 jobs:
   build:
     <<: *job_defaults


### PR DESCRIPTION
Follow-up that makes this config more explicit and hides a CircleCI warning saying that the version field is missing.