### PR TITLE
fix: check-clang-format not working on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ the latest upstream clang sources, make sure it is stripped and optimized
 ## Checking formatting
 
 Ensuring that changes to your code are properly formatted is an important part
-of your development workflow. We recommend using a git pre-commit hook. You can
-configure this as follows:
+of your development workflow. Note that the `check-clang-format` and
+`git-clang-format` commands require Python to be globally available.
+
+We recommend using a git pre-commit hook. You can configure this as follows:
 
 1. add a `precommit` script to your package.json file:
 

--- a/bin/check-clang-format.js
+++ b/bin/check-clang-format.js
@@ -60,7 +60,7 @@ function main(args) {
   }
 
   const gitClangFormatPath = path.join(clangFormatPath, 'bin/git-clang-format');
-  const result = spawn(gitClangFormatPath, ['--diff'], {encoding: 'utf-8'});
+  const result = spawn('python', [gitClangFormatPath, '--diff'], {encoding: 'utf-8'});
 
   if (result.error) {
     console.error('Error running git-clang-format:', result.error);


### PR DESCRIPTION
Currently when someone runs the "check-clang-format"
binary from the "clang-format" package on Windows, the
script will always fail. This is because on Windows the
file shebang is not respected. Therefore we can just explicitly
declare that we want to run the "python" executable in the
"PATH" environment variable. This ensures that the Python
script can be launched properly on windows.